### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
         run: |
             cd path/to/terraform/files && terraform init
 
-      - uses: env0/terratag-action
+      - uses: env0/terratag-action@main
         with:
           tags: |
             {


### PR DESCRIPTION
GitHub Actions require a reference to be explicitly specified. Without the `main`, this error is shown: `the 'uses' attribute must be a path, a Docker image, or owner/repo@ref`. 